### PR TITLE
Fix bug for when the first char is non-ascii char

### DIFF
--- a/lib/src/main/java/de/fxlae/typeid/lib/TypeIdLib.java
+++ b/lib/src/main/java/de/fxlae/typeid/lib/TypeIdLib.java
@@ -204,7 +204,8 @@ public final class TypeIdLib {
             return "Suffix with illegal length, must be " + SUFFIX_LENGTH;
         }
 
-        if (((SUFFIX_LOOKUP[input.charAt(start)] >>> 3) & 0x3) > 0) {
+        final char firstChar = input.charAt(start);
+        if ((firstChar < '0' || firstChar > '7')) {
             return "Illegal leftmost suffix character, must be one of [01234567]";
         }
 

--- a/lib/src/test/java/de/fxlae/typeid/lib/TypeIdLibTest.java
+++ b/lib/src/test/java/de/fxlae/typeid/lib/TypeIdLibTest.java
@@ -36,13 +36,14 @@ public class TypeIdLibTest {
                     "",
                     "_",
                     "someprefix_", // no suffix at all
-                    "_01h455vb4pex5vsknk084sn02q", // suffix only, but with preceding underscore
+                    "_01h455vb4pex5vsknk084sn02q", // suffix only, but with the preceding underscore
                     "__01h455vb4pex5vsknk084sn02q", // prefix is single underscore
                     "_someprefix_01h455vb4pex5vsknk084sn02q", // prefix starts with underscore
                     "someprefix__01h455vb4pex5vsknk084sn02q", // prefix ends with underscore
                     "_someprefix__01h455vb4pex5vsknk084sn02q", // prefix starts and ends with underscore
                     "sömeprefix_01h455vb4pex5vsknk084sn02q", // prefix with 'ö'
                     "someprefix_01h455öb4pex5vsknk084sn02q", // suffix with 'ö'
+                    "someprefix_Ă01h455b4pex5vsknk084sn02q", // suffix with 'Ă' (> ascii 255) as first char
                     "sOmeprefix_01h455vb4pex5vsknk084sn02q", // prefix with 'O'
                     "someprefix_01h455Vb4pex5vsknk084sn02q", // suffix with 'V'
                     "someprefix_01h455lb4pex5vsknk084sn02q", // suffix with 'l'


### PR DESCRIPTION
Crashes with:
Index 258 out of bounds for length 256
java.lang.ArrayIndexOutOfBoundsException:
Index 258 out of bounds for length 256

This adds a check for bigger SUFFIX_LOOKUP.length indexes for the first char.